### PR TITLE
Feature/gameover resource saving

### DIFF
--- a/kommandos/Camera.cpp
+++ b/kommandos/Camera.cpp
@@ -16,7 +16,7 @@ using namespace core;
 using namespace scene;
 
 /// <summary>	The camera start position. </summary>
-const vector3df cameraStartPosition = vector3df(0, 450, 0);
+const vector3df cameraStartPosition = vector3df(0, 150, 0);
 /// <summary>	The camera start target. </summary>
 const vector3df cameraStartTarget = vector3df(0, 0, 0);
 
@@ -57,10 +57,10 @@ void Camera::CameraInit()
 	{
 		camera->setPosition(cameraStartPosition);
 		camera->setTarget(cameraStartTarget);
-		newCameraPosition.Y = 180; //80
+		newCameraPosition.Y = 180; 
 	}
 }
-
+//
 ///-------------------------------------------------------------------------------------------------
 /// <summary>	Update camera position relative to the player while game is playing and move camera to start pos when game is over </summary>
 ///-------------------------------------------------------------------------------------------------

--- a/kommandos/Camera.cpp
+++ b/kommandos/Camera.cpp
@@ -57,7 +57,7 @@ void Camera::CameraInit()
 	{
 		camera->setPosition(cameraStartPosition);
 		camera->setTarget(cameraStartTarget);
-		newCameraPosition.Y = 180; 
+		newCameraPosition.Y = 80; 
 	}
 }
 //

--- a/kommandos/Camera.cpp
+++ b/kommandos/Camera.cpp
@@ -16,7 +16,7 @@ using namespace core;
 using namespace scene;
 
 /// <summary>	The camera start position. </summary>
-const vector3df cameraStartPosition = vector3df(0, 150, 0);
+const vector3df cameraStartPosition = vector3df(0, 450, 0);
 /// <summary>	The camera start target. </summary>
 const vector3df cameraStartTarget = vector3df(0, 0, 0);
 
@@ -42,6 +42,7 @@ Camera::Camera(IrrlichtDevice* device)
 {
 	cameraIDevice = device;
 	cameraSmgr = cameraIDevice->getSceneManager();
+	game_ = game_->GetInstance();
 	CameraInit();
 }
 
@@ -56,7 +57,7 @@ void Camera::CameraInit()
 	{
 		camera->setPosition(cameraStartPosition);
 		camera->setTarget(cameraStartTarget);
-		newCameraPosition.Y = 80;
+		newCameraPosition.Y = 180; //80
 	}
 }
 
@@ -66,8 +67,6 @@ void Camera::CameraInit()
 
 void Camera::CameraUpdate()
 {
-	game_ = game_->GetInstance();
-
 	if (game_->GetIsGameOver() == true)
 	{
 		camera->setPosition(cameraStartPosition);

--- a/kommandos/EnemySpawner.cpp
+++ b/kommandos/EnemySpawner.cpp
@@ -86,20 +86,20 @@ void EnemySpawner::UpdateEnemies()
 		}
 		if (game_EnemySpawner->GetIsGameOver() == true)
 		{
-			printf("enemy should be dead");
 			enemySpawnerSmgr->addToDeletionQueue(enemies[i]);
 			enemies.erase(i);
-			//enemyHealthValues.erase(i);
 		}
 	}
 
-	if (enemies.size() <= 0 && currentWave < maxWaves) {
+	if (enemies.size() <= 0 && currentWave < maxWaves) 
+	{
 		Spawn();
 		currentWave++;
 	}
 }
 
-void EnemySpawner::Spawn() {
+void EnemySpawner::Spawn() 
+{
 
 	for (int i = 0; i < amountOfEnemies; i++)
 	{
@@ -110,10 +110,12 @@ void EnemySpawner::Spawn() {
 	}
 }
 
-core::array<IMeshSceneNode*> EnemySpawner::getEnemies() {
+core::array<IMeshSceneNode*> EnemySpawner::getEnemies() 
+{
 	return enemies;
 }
 
-EnemyBehaviour* EnemySpawner::getEnemyBehaviour() {
+EnemyBehaviour* EnemySpawner::getEnemyBehaviour() 
+{
 	return enemyBehaviour;
 }

--- a/kommandos/EnemySpawner.cpp
+++ b/kommandos/EnemySpawner.cpp
@@ -7,6 +7,7 @@
 #include "EnemyBehaviour.h"
 #include "Player.h"
 #include "Collision.h"
+#include "Game.h"
 
 using namespace irr;
 using namespace core;
@@ -19,16 +20,19 @@ IrrlichtDevice* enemySpawnerIDevice;
 ISceneManager* enemySpawnerSmgr;
 EnemyBehaviour* enemyBehaviour;
 Player* _player;
+Game* game_EnemySpawner;
 Collision collision;
 
 array<vector3df> spawnPositions;
-u32 amountOfEnemies, Resize;
+u32 amountOfEnemies, resize;
 core::array<IMeshSceneNode*> enemies;
 u32 currentWave = 0;
 
 ParticleSystem* particle;
 const path bloodSplatter = "../media/blood.bmp";
 u32 prevFrameTime;
+
+
 
 EnemySpawner::EnemySpawner(IrrlichtDevice* device, Player* Player)
 {
@@ -37,14 +41,15 @@ EnemySpawner::EnemySpawner(IrrlichtDevice* device, Player* Player)
 	enemySpawnerSmgr = enemySpawnerIDevice->getSceneManager();
 	enemyBehaviour = new EnemyBehaviour(enemySpawnerIDevice);
 	_player = Player;
+	game_EnemySpawner = game_EnemySpawner->GetInstance();
 
 	amountOfEnemies = 6;
-	Resize = 2;
+	resize = 2;
 	//setting spawnpositions in the corners.
-	spawnPositions.push_back(vector3df(-82, 0, -78) * Resize);
-	spawnPositions.push_back(vector3df(78, 0, -78) * Resize);
-	spawnPositions.push_back(vector3df(78, 0, 78) * Resize);
-	spawnPositions.push_back(vector3df(-82, 0, 78) * Resize);
+	spawnPositions.push_back(vector3df(-82, 0, -78) * resize);
+	spawnPositions.push_back(vector3df(78, 0, -78) * resize);
+	spawnPositions.push_back(vector3df(78, 0, 78) * resize);
+	spawnPositions.push_back(vector3df(-82, 0, 78) * resize);
 
 	// In order to do framerate independent movement, we have to know
 	// how long it was since the last frame
@@ -53,8 +58,9 @@ EnemySpawner::EnemySpawner(IrrlichtDevice* device, Player* Player)
 	Spawn();
 }
 
-void EnemySpawner::UpdateEnemies() 
+void EnemySpawner::UpdateEnemies()
 {
+
 	// Work out a frame delta time.
 	const u32 now = enemySpawnerIDevice->getTimer()->getTime();
 	const f32 frameDeltaTime = (f32)(now - prevFrameTime) / 1000.f; // Time in seconds
@@ -63,7 +69,7 @@ void EnemySpawner::UpdateEnemies()
 	// Update all enemies
 	for (int i = 0; i < enemies.size(); i++)
 	{
-		if (!(_player->vulnerable > 0 && collision.SceneNodeWithSceneNode(_player->getPlayerObject(), enemies[i]))) 
+		if (!(_player->vulnerable > 0 && collision.SceneNodeWithSceneNode(_player->getPlayerObject(), enemies[i])))
 		{
 			if (enemyBehaviour->Update(enemies[i], _player->getPlayerObject()->getPosition(), frameDeltaTime))
 			{
@@ -77,6 +83,13 @@ void EnemySpawner::UpdateEnemies()
 			enemySpawnerSmgr->addToDeletionQueue(enemies[i]);
 			enemies.erase(i);
 			enemyHealthValues.erase(i);
+		}
+		if (game_EnemySpawner->GetIsGameOver() == true)
+		{
+			printf("enemy should be dead");
+			enemySpawnerSmgr->addToDeletionQueue(enemies[i]);
+			enemies.erase(i);
+			//enemyHealthValues.erase(i);
 		}
 	}
 

--- a/kommandos/Game.cpp
+++ b/kommandos/Game.cpp
@@ -108,9 +108,12 @@ void Game::Update()
 	prevFrame = currentFrame;
 
 	camera->CameraUpdate();
-	player->Move(inputReceiver);
 	enemySpawner->UpdateEnemies();
+	if (isGameOver != true)
+	{
+	player->Move(inputReceiver);
 	player->Shoot(inputReceiver, enemySpawner);
+	}
 }
 
 void Game::Draw()

--- a/kommandos/Player.cpp
+++ b/kommandos/Player.cpp
@@ -70,7 +70,8 @@ void Player::Init()
 		playerObject->addChild(gunNode);
 		gun = new Gun(gunNode, playerIDevice);
 	}
-	if (bullet) {
+	if (bullet)
+	{
 		bullet->setScale(vector3df(0.125f, 0.125f, 0.125f));
 		gunNode->setMaterialFlag(EMF_LIGHTING, false);
 		bullet->setVisible(false);
@@ -118,44 +119,53 @@ void Player::Move(InputReceiver inputReceiver)
 	if (playerCol.CollidesWithStaticObjects(playerObject))
 		playerObject->setPosition(currentPosition);
 
-	if (vulnerable > 0) { vulnerable -= frameDeltaTime; }
+	if (vulnerable > 0)
+	{
+		vulnerable -= frameDeltaTime;
+	}
 }
 
 void Player::Shoot(InputReceiver inputReceiver, EnemySpawner* enemies)
 {
-	if (inputReceiver.GetIsLeftMouseButtonPressed()) {
+
+	if (inputReceiver.GetIsLeftMouseButtonPressed())
+	{
 		gun->LaserLine(inputReceiver.GetMousePosition(), playerDriver, playerSmgr->getActiveCamera());
 		gun->Shoot(bullet);
 	}
-	if (gun->hasShot) {
-		for (int i = 0; i < enemies->getEnemies().size(); i++) {
-			if (playerCol.SceneNodeWithSceneNode(enemies->getEnemies()[i], bullet)) {
+	if (gun->hasShot)
+	{
+		for (int i = 0; i < enemies->getEnemies().size(); i++)
+		{
+			if (playerCol.SceneNodeWithSceneNode(enemies->getEnemies()[i], bullet)) 
+			{
 				enemies->enemyHealthValues[i] = enemies->getEnemyBehaviour()->TakeDamage(10, enemies->enemyHealthValues[i]);
 				playerScores.DisplayScore(10);
 			}
 		}
 	}
+
 }
 
 void Player::TakeDamage(f32 damage, f32 frameDeltaTime)
 {
-	if (health > 0 && vulnerable <= 0) {
+	if (health > 0 && vulnerable <= 0) 
+	{
 		vulnerable = 200;
 		health -= damage;
 
 		if (health <= 0)
 		{
-			//gameOverState.ShowGameOver(playerIDevice);  temp removal
+			gameOverState.ShowGameOver(playerIDevice);
 			game->SetIsGameOver(true);
-			playerObject->remove();
-			//playerSmgr->addToDeletionQueue(playerObject);
 		}
 	}
 
 }
 void Player::DrawHealthBar()
 {
-	if (game->GetIsGameOver() != true) {
+	if (game->GetIsGameOver() != true) 
+	{
 		const s32 barSize = MAXHEALTH;
 		//draws multiple bars to make i look nice
 		playerDriver->draw2DRectangle(SColor(255, 100, 100, 100), rect<s32>(x1Bar, y1Bar, (barSize * 5) + x2Bar, y2Bar));
@@ -169,6 +179,7 @@ void Player::DrawHealthBar()
 	}
 }
 
-ISceneNode* Player::getPlayerObject() {
+ISceneNode* Player::getPlayerObject() 
+{
 	return playerObject;
 }

--- a/kommandos/Player.cpp
+++ b/kommandos/Player.cpp
@@ -40,7 +40,9 @@ Player::Player(IrrlichtDevice* device)
 	playerIDevice = device;
 	playerDriver = playerIDevice->getVideoDriver();
 	playerSmgr = playerIDevice->getSceneManager();
+	game = game->GetInstance();
 	Init();
+
 
 	// In order to do framerate independent movement, we have to know
 	// how long it was since the last frame
@@ -137,32 +139,34 @@ void Player::Shoot(InputReceiver inputReceiver, EnemySpawner* enemies)
 
 void Player::TakeDamage(f32 damage, f32 frameDeltaTime)
 {
-	game = game->GetInstance();
 	if (health > 0 && vulnerable <= 0) {
-		vulnerable = 800;
+		vulnerable = 200;
 		health -= damage;
 
 		if (health <= 0)
 		{
-			gameOverState.ShowGameOver(playerIDevice);
+			//gameOverState.ShowGameOver(playerIDevice);  temp removal
 			game->SetIsGameOver(true);
+			playerObject->remove();
+			//playerSmgr->addToDeletionQueue(playerObject);
 		}
 	}
 
 }
 void Player::DrawHealthBar()
 {
-	const s32 barSize = MAXHEALTH;
-	//draws multiple bars to make i look nice
-	playerDriver->draw2DRectangle(SColor(255, 100, 100, 100), rect<s32>(x1Bar, y1Bar, (barSize * 5) + x2Bar, y2Bar));
-	playerDriver->draw2DRectangle(SColor(255, 125, 125, 125), rect<s32>(x1Bar + 1, y1Bar + 1, barSize * 5 + x2Bar - 1, y2Bar - 1));
-	playerDriver->draw2DRectangle(SColor(255, 150, 150, 150), rect<s32>(x1Bar + 3, y1Bar + 3, barSize * 5 + x2Bar - 3, y2Bar - 3));
-	playerDriver->draw2DRectangle(rect<s32>(x1Bar + 3, y1Bar + 3, health * 5 + x2Bar - 3, y2Bar - 3),
-		SColor(255, 255 - health * 2.55, health*2.55, 0),
-		SColor(255, 255 - health * 2.55, health*2.55, 0),
-		SColor(255, 255 - health * 2.55, health*2.55 - 150, 0),
-		SColor(255, 255 - health * 2.55, health*2.55 - 150, 0));
-
+	if (game->GetIsGameOver() != true) {
+		const s32 barSize = MAXHEALTH;
+		//draws multiple bars to make i look nice
+		playerDriver->draw2DRectangle(SColor(255, 100, 100, 100), rect<s32>(x1Bar, y1Bar, (barSize * 5) + x2Bar, y2Bar));
+		playerDriver->draw2DRectangle(SColor(255, 125, 125, 125), rect<s32>(x1Bar + 1, y1Bar + 1, barSize * 5 + x2Bar - 1, y2Bar - 1));
+		playerDriver->draw2DRectangle(SColor(255, 150, 150, 150), rect<s32>(x1Bar + 3, y1Bar + 3, barSize * 5 + x2Bar - 3, y2Bar - 3));
+		playerDriver->draw2DRectangle(rect<s32>(x1Bar + 3, y1Bar + 3, health * 5 + x2Bar - 3, y2Bar - 3),
+			SColor(255, 255 - health * 2.55, health*2.55, 0),
+			SColor(255, 255 - health * 2.55, health*2.55, 0),
+			SColor(255, 255 - health * 2.55, health*2.55 - 150, 0),
+			SColor(255, 255 - health * 2.55, health*2.55 - 150, 0));
+	}
 }
 
 ISceneNode* Player::getPlayerObject() {

--- a/kommandos/Player.cpp
+++ b/kommandos/Player.cpp
@@ -151,7 +151,7 @@ void Player::TakeDamage(f32 damage, f32 frameDeltaTime)
 {
 	if (health > 0 && vulnerable <= 0) 
 	{
-		vulnerable = 200;
+		vulnerable = 800;
 		health -= damage;
 
 		if (health <= 0)


### PR DESCRIPTION
Added check for gameover in game.cpp, player.cpp, enemyspawner.cpp. On game over: player functionality disabled (shoot, move)(player node still remains in-game however), enemies removed from game (score is still bugged), healthbar disabled. 